### PR TITLE
fix go build cache

### DIFF
--- a/articles/57a47a7381b9b3.md
+++ b/articles/57a47a7381b9b3.md
@@ -213,7 +213,9 @@ COPY go.mod go.sum .
 
 COPY . .
 -RUN go build -o app .
-+RUN --mount=type=cache,target=/root/.cache/go-build go build -o app .
++RUN --mount=type=cache,target=/go/pkg/mod \
++    --mount=type=cache,target=/root/.cache/go-build \
++    go build .
 
 FROM gcr.io/distroless/static-debian11:latest
 
@@ -222,6 +224,14 @@ WORKDIR /workdir
 COPY --from=build /workdir/blog-server /workdir/
 CMD ["/workdir/app"]
 ```
+
+:::message alert
+(2022/06/03追記)
+以下のようにビルド時に`/root/.cache/go-build/`だけを指定した例を記載していましたが、パッケージのダウンロードが走ってしまうことを[コメント](https://zenn.dev/link/comments/279b09d14cbfb4)で[@kitaminさん](https://zenn.dev/kitamin)に教えていただき、`/go/pkg/mod`も指定するように変更しました。
+```
+RUN --mount=type=cache,target=/root/.cache/go-build go build .
+```
+:::
 
 実際にGoのソースコードを少し書き変えると、ビルドは実行されても速くなっているのがわかります。
 ```diff


### PR DESCRIPTION
go buildのキャッシュには `/root/.cache/go-build/`だけでなく `/go/pkg/mod`も指定する必要があった